### PR TITLE
*fix missed const specifier for ParamLimited operator()

### DIFF
--- a/src/Cpl/Param.h
+++ b/src/Cpl/Param.h
@@ -391,9 +391,9 @@ namespace Cpl
     {
         typedef T Type;
 
-        CPL_INLINE ParamValidator<Type> operator () () 
+        CPL_INLINE ParamValidator<Type> operator () () const
         { 
-            return ParamValidator<Type>(this->_value, this->Default(), this->Min(), this->Max()); 
+            return ParamValidator<Type>((Type&) this->_value, this->Default(), this->Min(), this->Max()); 
         }
 
         virtual CPL_INLINE Type Min() const


### PR DESCRIPTION
In the current version, operator() cannot be called from a non-constant method. This code fix this issue, but use non-const type refference convertion. Maybe need use mutable keyword for _value field instead of this solution. 