### PR TITLE
Add operator() to ParamValidator class

### DIFF
--- a/src/Cpl/Param.h
+++ b/src/Cpl/Param.h
@@ -369,6 +369,11 @@ namespace Cpl
         { 
             return _value; 
         }
+        
+        const T& operator () () const
+        { 
+            return _value; 
+        }
 
         ParamValidator<Type>& operator = (const Type& value)
         {

--- a/src/Cpl/Prop.h
+++ b/src/Cpl/Prop.h
@@ -225,7 +225,7 @@ struct Param_##name : public Cpl::ParamProp<type> \
     typedef Cpl::ParamProp<type> Base; \
     Param_##name() : Base(#name) { this->_value = this->Default(); } \
     type Default() const override { return value; } \
-    String Description() const override { return descr; } \
+    Cpl::String Description() const override { return descr; } \
 } name;
 
 #define CPL_PROP_EX(type, name, value, min, max, descr) \
@@ -236,7 +236,7 @@ struct Param_##name : public Cpl::ParamProp<type> \
     type Default() const override { return value; } \
     type Min() const override { return min; } \
     type Max() const override { return max; } \
-    String Description() const override { return descr; } \
+    Cpl::String Description() const override { return descr; } \
     bool Limited() const override { return true; } \
 } name;
 


### PR DESCRIPTION
+added operator() for ParamValidator class, used at limited Param. (more comfortable way of getting value from ParamLimited)
*use Cpl::String class in macro definition (fix for differ String class in this macro call place)
