### PR TITLE
Fix bugs in Xml.h, String.h, File.h

### DIFF
--- a/src/Cpl/File.h
+++ b/src/Cpl/File.h
@@ -308,7 +308,7 @@ namespace Cpl
                 (fileAttribute & FILE_ATTRIBUTE_DIRECTORY) != 0);
 #elif __linux__
         struct stat buf;
-        int exists = stat( path_.c_str(), &buf );
+        int exists = stat( path.c_str(), &buf );
         return exists == 0 && S_ISDIR(buf.st_mode);
 #else
 #error Not supported system
@@ -644,11 +644,14 @@ namespace Cpl
             p = fs::canonical(p);
             return fs::absolute(p).string();
 #else
-            auto pos = path.find(path);
-            if (pos == String::npos || path.length() == path.length()) {
-                return {};
-            }
-            return path.substr(pos + path.length() + 1, path.length() - 1);
+            if (path.empty())
+                return path;
+            if (path[0] == '/')
+                return path;
+            String base = DirectoryByPath(basePath);
+            if (base.empty())
+                base = basePath;
+            return MakePath(base, path);
 #endif
         }
     }

--- a/src/Cpl/String.h
+++ b/src/Cpl/String.h
@@ -194,7 +194,7 @@ namespace Cpl
     template<class T> CPL_INLINE void ToVal(const String& string, T& value)
     {
         std::stringstream ss(string);
-        if(string != "" || string != " ")
+        if(string != "" && string != " ")
             ss >> value;
     }
 
@@ -206,7 +206,9 @@ namespace Cpl
 
     template<> CPL_INLINE void ToVal<size_t>(const String& string, size_t& value)
     {
-        ToVal(string, (ptrdiff_t&)value);
+        ptrdiff_t tmp;
+        ToVal(string, tmp);
+        value = static_cast<size_t>(tmp);
     }
 
     template<> CPL_INLINE void ToVal<bool>(const String& string, bool& value)

--- a/src/Cpl/Xml.h
+++ b/src/Cpl/Xml.h
@@ -1774,7 +1774,7 @@ namespace Cpl
             NodeIterator operator++(int)
             {
                 NodeIterator tmp = *this;
-                ++this;
+                ++(*this);
                 return tmp;
             }
 
@@ -1788,7 +1788,7 @@ namespace Cpl
             NodeIterator operator--(int)
             {
                 NodeIterator tmp = *this;
-                ++this;
+                --(*this);
                 return tmp;
             }
 
@@ -1849,7 +1849,7 @@ namespace Cpl
             AttributeIterator operator++(int)
             {
                 AttributeIterator tmp = *this;
-                ++this;
+                ++(*this);
                 return tmp;
             }
 
@@ -1863,7 +1863,7 @@ namespace Cpl
             AttributeIterator operator--(int)
             {
                 AttributeIterator tmp = *this;
-                ++this;
+                --(*this);
                 return tmp;
             }
 

--- a/src/Test/Test.cpp
+++ b/src/Test/Test.cpp
@@ -108,6 +108,8 @@ namespace Test
     TEST_ADD(YamlParam);
 
     TEST_ADD(XmlAllocateString);
+    TEST_ADD(XmlIterator);
+    TEST_ADD(ToValEmpty);
     TEST_ADD(DoFileModify);
     TEST_ADD(DoFileExistance);
     TEST_ADD(DoFileInfo);

--- a/src/Test/TestFile.cpp
+++ b/src/Test/TestFile.cpp
@@ -254,6 +254,14 @@ namespace Test
 
             ok &= COMPARE_RESULT(cnt5 == all_folders.size(), 1);
 
+            //Case if directory ends with multiple slashes
+            int cnt6 = 0;
+            for (auto& exist : all_folders){
+                cnt6 += COMPARE_RESULT(Cpl::DirectoryExists(exist + "///"), 1);
+            }
+
+            ok &= COMPARE_RESULT(cnt6 == all_folders.size(), 1);
+
             return ok;
         }
     }

--- a/src/Test/TestString.cpp
+++ b/src/Test/TestString.cpp
@@ -314,6 +314,34 @@ namespace Test
         return true;
     }
 
+    bool ToValEmptyTest()
+    {
+        // Empty and whitespace strings must not modify the value
+        int intVal = 42;
+        Cpl::ToVal(Cpl::String(""), intVal);
+        if (intVal != 42)
+            return false;
+
+        intVal = 42;
+        Cpl::ToVal(Cpl::String(" "), intVal);
+        if (intVal != 42)
+            return false;
+
+        // Normal parsing must work
+        intVal = 0;
+        Cpl::ToVal(Cpl::String("7"), intVal);
+        if (intVal != 7)
+            return false;
+
+        // size_t parsing
+        size_t sizeVal = 0;
+        Cpl::ToVal(Cpl::String("12345"), sizeVal);
+        if (sizeVal != 12345)
+            return false;
+
+        return true;
+    }
+
     bool TimeToStrTest()
     {
         std::vector<std::pair<double, std::pair<Cpl::String, Cpl::String>>> testCases =

--- a/src/Test/TestXml.cpp
+++ b/src/Test/TestXml.cpp
@@ -147,4 +147,81 @@ namespace Test
 
         return true;
     }
+
+    bool XmlIteratorTest()
+    {
+        using namespace Cpl::Xml;
+
+        std::string xml = "<root a1=\"1\" a2=\"2\" a3=\"3\"><c1/><c2/><c3/></root>";
+        std::vector<char> buf(xml.begin(), xml.end());
+        buf.push_back('\0');
+
+        XmlDocument<char> doc;
+        doc.Parse<0>(buf.data(), buf.size());
+        XmlNode<char>* root = doc.FirstNode();
+        if (!root)
+            return false;
+
+        // NodeIterator: postfix ++ returns old value, advances iterator
+        {
+            NodeIterator<char> it(root);
+            std::string first = it->Name();
+            NodeIterator<char> prev = it++;
+            std::string second = it->Name();
+
+            if (std::string(prev->Name()) != first)
+                return false;
+            if (first == second)
+                return false;
+            if (first != "c1" || second != "c2")
+                return false;
+        }
+
+        // NodeIterator: postfix -- returns old value, goes backward
+        {
+            NodeIterator<char> it(root);
+            ++it; // c2
+            ++it; // c3
+            std::string third = it->Name();
+            NodeIterator<char> prev = it--;
+            std::string second = it->Name();
+
+            if (std::string(prev->Name()) != third)
+                return false;
+            if (third != "c3" || second != "c2")
+                return false;
+        }
+
+        // AttributeIterator: postfix ++ returns old value, advances iterator
+        {
+            AttributeIterator<char> it(root);
+            std::string first = it->Name();
+            AttributeIterator<char> prev = it++;
+            std::string second = it->Name();
+
+            if (std::string(prev->Name()) != first)
+                return false;
+            if (first == second)
+                return false;
+            if (first != "a1" || second != "a2")
+                return false;
+        }
+
+        // AttributeIterator: postfix -- returns old value, goes backward
+        {
+            AttributeIterator<char> it(root);
+            ++it; // a2
+            ++it; // a3
+            std::string third = it->Name();
+            AttributeIterator<char> prev = it--;
+            std::string second = it->Name();
+
+            if (std::string(prev->Name()) != third)
+                return false;
+            if (third != "a3" || second != "a2")
+                return false;
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
## Fixes

- **Xml.h**: fix postfix iterator operators — `++this` doesn't increment the iterator (and doesn't compile when instantiated); `operator--(int)` was incrementing instead of decrementing
- **String.h**: fix always-true condition in `ToVal` (`||` → `&&`)
- **String.h**: eliminate strict aliasing UB in `ToVal<size_t>` — replace `(ptrdiff_t&)value` with a temporary variable
- **File.h**: fix `DirectoryExists` on Linux — `stat()` was called on original `path_` instead of trimmed `path`
- **File.h**: fix broken `GetAbsolutePath` non-filesystem fallback — `path.find(path)` always returns 0 and `path.length() == path.length()` is always true

## Tests

- `XmlIteratorTest`: postfix `++`/`--` for `NodeIterator` and `AttributeIterator`
- `ToValEmptyTest`: empty/whitespace strings don't modify value; `size_t` parsing
- `DirectoryExists`: trailing multiple slashes