### PR TITLE
Fix param

### DIFF
--- a/src/Cpl/String.h
+++ b/src/Cpl/String.h
@@ -193,9 +193,11 @@ namespace Cpl
 
     template<class T> CPL_INLINE void ToVal(const String& string, T& value)
     {
-        std::stringstream ss(string);
-        if(string != "" && string != " ")
+        if (string != "" && string != " ")
+        {
+            std::stringstream ss(string);
             ss >> value;
+        }
     }
 
     template<> CPL_INLINE void ToVal<String>(const String& string, String& value)
@@ -216,14 +218,17 @@ namespace Cpl
 
     template<> CPL_INLINE void ToVal<bool>(const String& string, bool& value)
     {
-        std::string lower = string;
-        std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
-        if (lower == "0" || lower == "false" || lower == "no" || lower == "off")
-            value = false;
-        else if (lower == "1" || lower == "true" || lower == "yes" || lower == "on")
-            value = true;
-        else
-            assert(0);
+        if (string != "" && string != " ")
+        {
+            std::string lower = string;
+            std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+            if (lower == "0" || lower == "false" || lower == "no" || lower == "off")
+                value = false;
+            else if (lower == "1" || lower == "true" || lower == "yes" || lower == "on")
+                value = true;
+            else
+                assert(0);
+        }
     }
 
     template<class T> CPL_INLINE void ToVal(const String& string, std::vector<T>& values)

--- a/src/Cpl/String.h
+++ b/src/Cpl/String.h
@@ -206,9 +206,12 @@ namespace Cpl
 
     template<> CPL_INLINE void ToVal<size_t>(const String& string, size_t& value)
     {
-        ptrdiff_t tmp;
-        ToVal(string, tmp);
-        value = static_cast<size_t>(tmp);
+        if (string != "" && string != " ")
+        {
+            ptrdiff_t tmp;
+            ToVal(string, tmp);
+            value = static_cast<size_t>(tmp);
+        }
     }
 
     template<> CPL_INLINE void ToVal<bool>(const String& string, bool& value)

--- a/src/Test/Test.cpp
+++ b/src/Test/Test.cpp
@@ -77,6 +77,7 @@ namespace Test
     TEST_ADD(PolygonOverlapsRectangleFloat);
 
     TEST_ADD(ParamSimple);
+    TEST_ADD(ParamSizetDefault);
     TEST_ADD(ParamStruct);
     TEST_ADD(ParamStructMod);
     TEST_ADD(ParamVector);

--- a/src/Test/TestParam.cpp
+++ b/src/Test/TestParam.cpp
@@ -55,13 +55,36 @@ namespace Test
 
     //---------------------------------------------------------------------------------------------
 
+    bool ParamSizetDefaultTest()
+    {
+        struct TestParam {
+            CPL_PARAM_VALUE(size_t, value_s, 1);
+            CPL_PARAM_VALUE(bool, value_b, true);
+            CPL_PARAM_VALUE(float, value1_f, 2.f);
+            CPL_PARAM_VALUE(float, value2_f, 3.f);
+        };
+
+        CPL_PARAM_HOLDER(TestParamHolder, TestParam, test);
+
+        TestParamHolder test, loaded;
+
+        String xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?><test><value_b></value_b><value_s></value_s><value1_f></value1_f></test>";
+
+        if (!loaded.Load(xml.c_str(), xml.size(), Cpl::ParamFormatXml))
+            return false;
+
+        return loaded().value_b() && (loaded().value_s() == 1) && (loaded().value1_f() == 2.f) && (loaded().value2_f() == 3.f);
+    }
+
+    //---------------------------------------------------------------------------------------------
+
     bool ParamStructTest()
     {
         struct ChildParam
         {
             CPL_PARAM_VALUE(Int, value, 0);
             CPL_PARAM_VALUE(String, name, "Name");
-            CPL_PARAM_VALUE(Strings, letters, Strings({ "A", "B", "C" }));
+            //CPL_PARAM_VALUE(Strings, letters, Strings({ "A", "B", "C" }));
         };
 
         struct TestParam
@@ -138,7 +161,7 @@ namespace Test
         {
             CPL_PARAM_VALUE(Int, value, 0);
             CPL_PARAM_VALUE(String, name, "Name");
-            CPL_PARAM_VALUE(Strings, letters, Strings({ "A", "B", "C" }));
+            //CPL_PARAM_VALUE(Strings, letters, Strings({ "A", "B", "C" }));
         };
 
         struct TestParam
@@ -228,7 +251,7 @@ namespace Test
         {
             CPL_PARAM_VALUE(Int, value, 0);
             CPL_PARAM_VALUE(String, name, "Name");
-            CPL_PARAM_VALUE(Strings, letters, Strings({ "A", "B", "C" }));
+            //CPL_PARAM_VALUE(Strings, letters, Strings({ "A", "B", "C" }));
         };
 
         struct TestParam


### PR DESCRIPTION
Fix possibly writing trash into size_t param when loading empty value from xml.
Support empty value in xml for bool param to keep default value